### PR TITLE
Add images in coin and dice module #128

### DIFF
--- a/modules/src/coin.py
+++ b/modules/src/coin.py
@@ -1,10 +1,14 @@
 import json
 import random
-from templates.text import TextTemplate
+from templates.attachment import AttachmentTemplate
 from templates.quick_replies import add_quick_reply
 
+#images by US Mint; published on wikimedia under public domain rights.
+coin_images = {'heads': 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a0/2006_Quarter_Proof.png/244px-2006_Quarter_Proof.png',
+               'tails': 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Oregon_quarter%2C_reverse_side%2C_2005.jpg/236px-Oregon_quarter%2C_reverse_side%2C_2005.jpg'}
+
 def process(input, entities=None):
-    toss = TextTemplate(random.choice(['heads', 'tails'])).get_message()
+    toss = AttachmentTemplate(random.choice(list(coin_images.values())), type='image').get_message()
     postback = {
         'intent': 'coin',
         'entities': None

--- a/modules/src/dice.py
+++ b/modules/src/dice.py
@@ -3,8 +3,15 @@ import random
 from templates.text import TextTemplate
 from templates.quick_replies import add_quick_reply
 
+dice_sides = {1: u"\u2680",
+              2: u"\u2681",
+              3: u"\u2682",
+              4: u"\u2683",
+              5: u"\u2684",
+              6: u"\u2685"}
+
 def process(input, entities=None):
-    roll = TextTemplate(str(random.randint(1, 6))).get_message()
+    roll = TextTemplate(dice_sides[random.randint(1, 6)].encode('utf-8')).get_message()
     postback = {
         'intent': 'dice',
         'entities': None


### PR DESCRIPTION
Hi,
I changed the output of the coin module to give back an attachment with an image of a US quarter. The images were taken from wikimedia commons and are under public domain rights, so using them should be fine as I understand.
For the dice module I had the idea to use the unicode characters representing the dice sides, which should be more efficient. I wasn't able to test whether Facebook messenger would convert the unicode escape into the right symbol, but according to this quora thread (https://www.quora.com/Can-Messenger-Bots-reply-with-emoji-How) it should work. If there is a way to test it iin facebook messenger, I am happy to do it, but as I am new to using the facebook api I would need a hint. Thanks.