### PR TITLE
Add command line support for JARVIS

### DIFF
--- a/jarvis_cmd.py
+++ b/jarvis_cmd.py
@@ -1,0 +1,33 @@
+import urllib
+import ast
+import signal
+import sys
+
+ascii_art = """\
+
+
+  jjj                        iii      
+        aa aa rr rr  vv   vv      sss 
+  jjj  aa aaa rrr  r  vv vv  iii s    
+  jjj aa  aaa rr       vvv   iii  sss 
+  jjj  aaa aa rr        v    iii     s
+jjjj                              sss 
+
+Press Ctrl+C to quit
+"""
+print(ascii_art)
+
+while True:
+	try:
+		user_input = raw_input('query> ')
+	
+		url = "http://localhost:5000/search/?q=" + user_input
+		# opening the url
+		output_raw = urllib.urlopen(url).read()
+		output_dict = ast.literal_eval(output_raw)
+		print(output_dict["text"])
+
+	except KeyboardInterrupt:
+		print('\nSee ya!')
+		sys.exit(0)	
+	


### PR DESCRIPTION
I thought adding a command line version of JARVIS would interest the *nix userbase. 

So the basic idea for this is you have a script that runs JARVIS in the background, and when ever you want to query it, you just open a terminal and enter your query. This is what I'm doing right now:
![jarvisscreen](https://cloud.githubusercontent.com/assets/17672379/21600357/f0b6eea0-d1a0-11e6-9f35-7f131c11c1f5.png)

I still need to add some kind of shell script that you can have JARVIS in `/bin`, y'know so you can make calls to JARVIS without having to `cd` to the directory and run it using Python.

What are your thoughts?