### PR TITLE
downgrade to html5lib version compatible with bs4.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ requests-cache==0.4.13
 six==1.10.0
 Werkzeug==0.11.8
 wikipedia==1.4.0
+html5lib==0.9999999


### PR DESCRIPTION
'module' object has no attribute '_base' error with html5lib version 1.04, so downgrade to 0.9999999