### PR TITLE
Move Anime module over to Kitsu API

### DIFF
--- a/modules/src/anime.py
+++ b/modules/src/anime.py
@@ -2,24 +2,30 @@ import requests
 import requests_cache
 from templates.button import *
 
+KITSU_URL = 'https://kitsu.io/anime/'
+
 def process(input, entities):
     output = {}
     try:
         anime = entities['anime'][0]['value']
-
         with requests_cache.enabled('anime_cache', backend='sqlite', expire_after=86400):
-            r = requests.get('https://hummingbird.me/api/v1/search/anime', params={
-                'query': anime
+            r = requests.get('https://kitsu.io/api/edge/anime', params={
+                'filter[text]': anime
             })
             data = r.json()
 
+        top_result = data['data'][0]
+        english_title = top_result['attributes']['titles']['en']
+        synopsis = top_result['attributes']['synopsis']
+        avg_rating = top_result['attributes']['averageRating']
+
         template = TextTemplate()
-        template.set_text('Title: ' + data[0]['title'] + '\nSynopsis: ' + data[0]['synopsis'])
-        template.set_post_text('\nCommunity Rating: ' + str(round(data[0]['community_rating'], 2)) + ' / 5' + '\nStatus: ' + data[0]['status'])
+        template.set_text('Title: ' + english_title + '\nSynopsis: ' + synopsis)
+        template.set_post_text('\nCommunity Rating: ' + str(round(avg_rating, 2)) + ' / 5')
         text = template.get_text()
 
         template = ButtonTemplate(text)
-        template.add_web_url('Hummingbird URL', data[0]['url'])
+        template.add_web_url('Kitsu URL', KITSU_URL + top_result['attributes']['slug'])
 
         output['input'] = input
         output['output'] = template.get_message()
@@ -28,7 +34,6 @@ def process(input, entities):
         error_message = 'I couldn\'t find any anime matching your query.'
         error_message += '\nPlease ask me something else, like:'
         error_message += '\n  - Death Note anime'
-        error_message += '\n  - Dragon ball super anime status'
         error_message += '\n  - What is the anime rating of One Punch Man?'
         output['error_msg'] = TextTemplate(error_message).get_message()
         output['success'] = False

--- a/modules/src/anime.py
+++ b/modules/src/anime.py
@@ -2,30 +2,26 @@ import requests
 import requests_cache
 from templates.button import *
 
-KITSU_URL = 'https://kitsu.io/anime/'
-
 def process(input, entities):
     output = {}
     try:
         anime = entities['anime'][0]['value']
+
         with requests_cache.enabled('anime_cache', backend='sqlite', expire_after=86400):
             r = requests.get('https://kitsu.io/api/edge/anime', params={
                 'filter[text]': anime
             })
             data = r.json()
 
-        top_result = data['data'][0]
-        english_title = top_result['attributes']['titles']['en']
-        synopsis = top_result['attributes']['synopsis']
-        avg_rating = top_result['attributes']['averageRating']
+        top_anime = data['data'][0]['attributes']
 
         template = TextTemplate()
-        template.set_text('Title: ' + english_title + '\nSynopsis: ' + synopsis)
-        template.set_post_text('\nCommunity Rating: ' + str(round(avg_rating, 2)) + ' / 5')
+        template.set_text('Title: ' + top_anime['canonicalTitle'] + '\nSynopsis: ' + top_anime['synopsis'])
+        template.set_post_text('\nAverage Rating: ' + top_anime['averageRating'] + '%')
         text = template.get_text()
 
         template = ButtonTemplate(text)
-        template.add_web_url('Kitsu URL', KITSU_URL + top_result['attributes']['slug'])
+        template.add_web_url('Kitsu URL', 'https://kitsu.io/anime/' + top_anime['slug'])
 
         output['input'] = input
         output['output'] = template.get_message()
@@ -34,6 +30,7 @@ def process(input, entities):
         error_message = 'I couldn\'t find any anime matching your query.'
         error_message += '\nPlease ask me something else, like:'
         error_message += '\n  - Death Note anime'
+        error_message += '\n  - Dragon ball super anime status'
         error_message += '\n  - What is the anime rating of One Punch Man?'
         output['error_msg'] = TextTemplate(error_message).get_message()
         output['success'] = False


### PR DESCRIPTION
**Fixes issue #157**

I have moved the `anime` module's API from Hummingbird to Kitsu. It provides mostly the same attributes for the anime result except for **"Status"** so I have removed that line in the output.

All tests are passing.