### PR TITLE
add images to ping response

### DIFF
--- a/modules/src/ping.py
+++ b/modules/src/ping.py
@@ -18,16 +18,17 @@ def process(input, entities):
         status = data['status_code']
         if status == 1:
             text = hostname + ' is up.'
-            image_url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Arbcom_ru_ready.svg/240px-Arbcom_ru_ready.svg.png'
+            image_url = 'http://fa2png.io/r/font-awesome/check-circle/?color=c0392b&margin=0&size=256'
         elif status == 2:
             text = hostname + ' seems to be down!'
-            image_url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Arbcom_ru_withdrawn.svg/240px-Arbcom_ru_withdrawn.svg.png'
+            image_url = 'http://fa2png.io/r/font-awesome/times-circle/?color=c0392b&margin=0&size=256'
         elif status == 3:
             text = 'Please enter a valid domain to check availability.'
-            image_url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Twemoji_2755.svg/240px-Twemoji_2755.svg.png'
+            image_url = 'http://fa2png.io/r/font-awesome/exclamation-circle/?color=f1c40f&margin=0&size=256'
         else:
             raise Exception("Something unexpected happened!")
         template = GenericTemplate()
+
         template.add_element(title=text, image_url=image_url)
         output['input'] = input
         output['output'] = template.get_message()

--- a/modules/src/ping.py
+++ b/modules/src/ping.py
@@ -18,17 +18,17 @@ def process(input, entities):
         status = data['status_code']
         if status == 1:
             text = hostname + ' is up.'
-            image_url = 'http://fa2png.io/r/font-awesome/check-circle/?color=c0392b&margin=0&size=256'
+            image_url = 'http://fa2png.io/media/icons/font-awesome/4-6-3/check-circle/256/0/27ae60_none.png'
         elif status == 2:
             text = hostname + ' seems to be down!'
-            image_url = 'http://fa2png.io/r/font-awesome/times-circle/?color=c0392b&margin=0&size=256'
+            image_url = 'http://fa2png.io/media/icons/font-awesome/4-6-3/times-circle/256/0/c0392b_none.png'
         elif status == 3:
             text = 'Please enter a valid domain to check availability.'
-            image_url = 'http://fa2png.io/r/font-awesome/exclamation-circle/?color=f1c40f&margin=0&size=256'
+            image_url = 'http://fa2png.io/media/icons/font-awesome/4-6-3/exclamation-circle/256/0/f1c40f_none.png'
         else:
             raise Exception("Something unexpected happened!")
         template = GenericTemplate()
-
+        template.set_image_aspect_ratio_to_square()
         template.add_element(title=text, image_url=image_url)
         output['input'] = input
         output['output'] = template.get_message()

--- a/modules/src/ping.py
+++ b/modules/src/ping.py
@@ -1,5 +1,6 @@
 import requests
 
+from templates.generic import *
 from templates.text import TextTemplate
 from urlparse import urlparse
 
@@ -17,14 +18,19 @@ def process(input, entities):
         status = data['status_code']
         if status == 1:
             text = hostname + ' is up.'
+            image_url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Arbcom_ru_ready.svg/240px-Arbcom_ru_ready.svg.png'
         elif status == 2:
             text = hostname + ' seems to be down!'
+            image_url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Arbcom_ru_withdrawn.svg/240px-Arbcom_ru_withdrawn.svg.png'
         elif status == 3:
             text = 'Please enter a valid domain to check availability.'
+            image_url = 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Twemoji_2755.svg/240px-Twemoji_2755.svg.png'
         else:
             raise Exception("Something unexpected happened!")
+        template = GenericTemplate()
+        template.add_element(title=text, image_url=image_url)
         output['input'] = input
-        output['output'] = TextTemplate(text).get_message()
+        output['output'] = template.get_message()
         output['success'] = True
     except:
         error_message = 'There seems to be a problem looking up that domain.'


### PR DESCRIPTION
Here is my first go at adding images for the ping response. Using the following images for statuses 1, 2, and 3 respectively.

![](https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Arbcom_ru_ready.svg/240px-Arbcom_ru_ready.svg.png)
![](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Arbcom_ru_withdrawn.svg/240px-Arbcom_ru_withdrawn.svg.png)
![](https://upload.wikimedia.org/wikipedia/commons/thumb/e/e2/Twemoji_2755.svg/240px-Twemoji_2755.svg.png)

Wasn't sure about size, or how to test appearance within Messenger to see how 240x240 scales.

First PR, any and all feedback on code and PR itself is much appreciated.