### PR TITLE
Updated GET request in anime.py module to only pull one result

### DIFF
--- a/modules/src/anime.py
+++ b/modules/src/anime.py
@@ -11,7 +11,8 @@ def process(input, entities):
 
         with requests_cache.enabled('anime_cache', backend='sqlite', expire_after=86400):
             r = requests.get('https://kitsu.io/api/edge/anime', params={
-                'filter[text]': anime
+                'filter[text]': anime,
+                'page[limit]': 1
             })
             data = r.json()
 


### PR DESCRIPTION
From what I could see, the anime.py module was the only one pulling more than one search result. All the other API calls that could return multiple results already had an "&limit=1" flag. This should resolve #208 .