### PR TITLE
Dice module extension

### DIFF
--- a/modules/src/dice.py
+++ b/modules/src/dice.py
@@ -2,6 +2,7 @@ import random
 
 import modules
 from templates.attachment import AttachmentTemplate
+from templates.text import TextTemplate
 from templates.quick_replies import add_quick_reply
 
 dice_sides = {
@@ -14,13 +15,32 @@ dice_sides = {
 }
 
 
-def process(input, entities=None):
-    message = AttachmentTemplate(dice_sides[random.randint(1, 6)], type='image').get_message()
-    message = add_quick_reply(message, 'Roll again!', modules.generate_postback('dice'))
-    message = add_quick_reply(message, 'Flip a coin.', modules.generate_postback('coin'))
-    output = {
-        'input': input,
-        'output': message,
-        'success': True
-    }
+def process(input, entities):
+    try:
+        message = None
+        dice = entities['dice'][0]['value']
+        if (dice == "d6"):
+            message = AttachmentTemplate(dice_sides[random.randint(1, 6)], type='image').get_message()
+        else:
+            sides = int(dice[1:])
+            message = TextTemplate("I rolled a " + dice + " and got " + str(random.randint(1, sides))).get_message()
+        message = add_quick_reply(message, 'Roll again!', modules.generate_postback('dice'))
+        message = add_quick_reply(message, 'Flip a coin.', modules.generate_postback('coin'))
+        output = {
+            'input': input,
+            'output': message,
+            'success': True
+        }
+    except:
+        error =  "I'm sorry, something went wrong when rolling the dice."
+        error += "\nI might not be certain what kind of dice you're trying to roll."
+        error += "\nI can roll a d4, d6, d10, d12, d20, or d100 (d%)."
+        error += "\nPlease phrase your request more like this:"
+        error += "\n  - Roll a d6"
+        error += "\n  - Jarvis, roll a die"
+        error += "\n  - Can you roll a d20?"
+        output = {
+            'error_msg': error,
+            'success': False
+        }
     return output

--- a/modules/tests/test_dice.py
+++ b/modules/tests/test_dice.py
@@ -3,6 +3,12 @@ import modules
 
 def test_dice():
     assert ('dice' == modules.process_query('Roll a dice')[0])
+    assert ('dice' == modules.process_query('Roll a die')[0])
     assert ('dice' == modules.process_query('Jarvis, roll a dice')[0])
+    assert ('dice' == modules.process_query('Jarvis, roll a die')[0])
+    assert ('dice' == modules.process_query('Jarvis, roll a d4')[0])
     assert ('dice' == modules.process_query('Can you roll a dice?')[0])
+    assert ('dice' == modules.process_query('Roll a d6')[0])
+    assert ('dice' == modules.process_query('Roll a D6')[0])
+    assert ('dice' == modules.process_query('Roll a D20')[0])
     assert ('dice' != modules.process_query('something random')[0])


### PR DESCRIPTION
# WARNING: I kept the code that generates a quick-reply to roll the dice again, but I have no way of testing if it will still work after these changes. It seems like modules.generate_postback() might need to be extended so that entities can be specified, but maybe not. I don't understand how it works. I tested everything else though.

## Changes
Added the following dice:
- d4
- d8
- d10
- d12
- d20
- d% (d100)

## Expected wit.ai Changes
This extension expects wit.ai to return a "dice" entity containing one of the following values:

- 'd4'
- 'd6'
- 'd8'
- 'd10'
- 'd12'
- 'd20'
- 'd100'

The phrases that Jarvis should respond to are essentially the same, except the user can now specify one of these dice types. However, "roll a dice" and "roll a die" should return 'd6', and "roll a d%" and "roll a d00" should return 'd100'. The user should also be able to capitalize the dice symbol, so "D6", "D12", etc. should also return the appropriate tag.