### PR TITLE
Added support for both new and old API's response structure

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -29,7 +29,6 @@ def process_query(input):
         entities = data['outcomes'][0]['entities']
         confidence = data['outcomes'][0]['confidence'] if 'intent' not in data['outcomes'][0] \
             ['entities'] else data['outcomes'][0]['entities']['intent'][0]['confidence']
-        print intent, confidence
         if intent in src.__all__ and confidence > 0.5:
             return intent, entities
         else:

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -24,9 +24,10 @@ def process_query(input):
             'Authorization': 'Bearer %s' % WIT_AI_ACCESS_TOKEN
         })
         data = r.json()
-        intent = data['outcomes'][0]['intent']
+        intent = data['outcomes'][0]['intent'] if 'intent' not in data['outcomes'][0]['entities'] else data['outcomes'][0]['entities']['intent'][0]['value']
         entities = data['outcomes'][0]['entities']
-        confidence = data['outcomes'][0]['confidence']
+        confidence = data['outcomes'][0]['confidence'] if 'intent' not in data['outcomes'][0]['entities'] else data['outcomes'][0]['entities']['intent'][0]['confidence']
+        print intent, confidence
         if intent in src.__all__ and confidence > 0.5:
             return intent, entities
         else:

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -24,9 +24,11 @@ def process_query(input):
             'Authorization': 'Bearer %s' % WIT_AI_ACCESS_TOKEN
         })
         data = r.json()
-        intent = data['outcomes'][0]['intent'] if 'intent' not in data['outcomes'][0]['entities'] else data['outcomes'][0]['entities']['intent'][0]['value']
+        intent = data['outcomes'][0]['intent'] if 'intent' not in data['outcomes'][0] \
+            ['entities'] else data['outcomes'][0]['entities']['intent'][0]['value']
         entities = data['outcomes'][0]['entities']
-        confidence = data['outcomes'][0]['confidence'] if 'intent' not in data['outcomes'][0]['entities'] else data['outcomes'][0]['entities']['intent'][0]['confidence']
+        confidence = data['outcomes'][0]['confidence'] if 'intent' not in data['outcomes'][0] \
+            ['entities'] else data['outcomes'][0]['entities']['intent'][0]['confidence']
         print intent, confidence
         if intent in src.__all__ and confidence > 0.5:
             return intent, entities


### PR DESCRIPTION
The newest version of wit.ai uses a different response structure. In this new structure, "intent" is NOT a separate key, instead it is integrated in "entities". 

So, when new contributors teaches the WIT ai to work with their module, they will face problems because JARVIS uses older api version which uses different response structure.