### PR TITLE
Changed 'offline' sources in README to 'JARVIS'

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ Feel free to add to this list by opening an Issue / Pull Request.
 | currency | usd to eur rate | Fixer.io |
 | dice | roll a die | --- |
 | dictionary | define comfort | Words API |
-| fact | tell me a fact | [Offline](https://github.com/swapagarwal/JARVIS-on-Messenger/blob/master/data/facts.json) |
+| fact | tell me a fact | [JARVIS](https://github.com/swapagarwal/JARVIS-on-Messenger/blob/master/data/facts.json) |
 | hello | Hi, Jarvis! | --- |
 | help | What can you do? | --- |
-| joke | tell me a joke | [Offline](https://github.com/swapagarwal/JARVIS-on-Messenger/blob/master/data/jokes.json) |
+| joke | tell me a joke | [JARVIS](https://github.com/swapagarwal/JARVIS-on-Messenger/blob/master/data/jokes.json) |
 | lyrics | paradise lyrics | Powered by musiXmatch |
 | movie | iron man 2 movie plot | <img src="/images/powered_by_tmdb.png"/> |
 | music | songs by linkin park | Spotify |
 | news | latest news | Powered by NewsAPI |
 | ping | ping google.com | Is it up? |
-| quote | random quote | [Offline](https://github.com/swapagarwal/JARVIS-on-Messenger/blob/master/data/quotes.json) |
+| quote | random quote | [JARVIS](https://github.com/swapagarwal/JARVIS-on-Messenger/blob/master/data/quotes.json) |
 | request | report a bug <br> request a feature | --- |
 | thanks | Thank you! | --- |
 | time | time in seattle | TimeZoneDB API |


### PR DESCRIPTION
I thought that referring to the sources with local data files as "Offline" unnecessarily suggested that the modules weren't operational. So I changed their sources to "JARVIS" to show that the outputs are coming from data files within this project.