### PR TITLE
Video: Fix query breaking on a channel result

### DIFF
--- a/modules/src/video.py
+++ b/modules/src/video.py
@@ -19,7 +19,8 @@ def process(input, entities):
                 'https://www.googleapis.com/youtube/v3/search?part=snippet&maxResults=10&q=' + video + '&type=video&key=' + YOUTUBE_DATA_API_KEY)
             data = r.json()
         template = GenericTemplate()
-        for item in data['items']:
+        videos = [item for item in data['items'] if item['id']['kind'] == 'youtube#video']
+        for item in videos:
             title = item['snippet']['title']
             item_url = 'https://www.youtube.com/watch?v=' + item['id']['videoId']
             image_url = item['snippet']['thumbnails']['high']['url']


### PR DESCRIPTION
Fixes #297

* Update video.py

There appears to be an issue with the YouTube Data API that is causing
it to return channel results from the /search API. Added a filter to
the returned API data to filter out all non-video results.

See: https://stackoverflow.com/questions/45527041/youtube-api-video-only-search-returning-a-channel-object

The above issue is only encountered on some queries and not all, for example "sia videos" would return a channel result while "eminem videos" would not.