### PR TITLE
Added a basic coafile

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -1,0 +1,7 @@
+[all]
+files = **.py
+language = python2
+
+[cli]
+bears = PEP8Bear, SpaceConsistencyBear, PyImportSortBear
+use_spaces = True


### PR DESCRIPTION
I have added a very basic coala integration. Currently it checks all the python files for PEP8 violations, correct whitespace usage and whether the imports are sorted or not.

This fixes #304 