### PR TITLE
resolves #370: add test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,5 @@ cache: pip
 install:
   - pip install -r requirements.txt
 script:
-  - py.test -n 8 -v
+  - py.test -n 8 -v --cov=./
+  - codecov

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Just A Rather Very Intelligent System, now on Messenger!
 
 [![Build Status](https://travis-ci.org/swapagarwal/JARVIS-on-Messenger.svg?branch=master)](https://travis-ci.org/swapagarwal/JARVIS-on-Messenger)
+[![Code Coverage](https://codecov.io/gh/swapagarwal/JARVIS-on-Messenger/branch/master/graph/badge.svg)](https://codecov.io/gh/swapagarwal/JARVIS-on-Messenger)
 ![Python](https://img.shields.io/badge/python-2.7-blue.svg)
 [![PEP8](https://img.shields.io/badge/code%20style-pep8-orange.svg)](https://www.python.org/dev/peps/pep-0008/)
 [![Gitmoji](https://img.shields.io/badge/gitmoji-%20🚀%20🐳-FFDD67.svg)](https://gitmoji.carloscuesta.me)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 apipkg==1.4
 beautifulsoup4==4.4.1
 cffi==1.5.2
+codecov==2.0.12
 cryptography==1.3.1
 decorator==4.1.2
 enum34==1.1.3
@@ -25,6 +26,7 @@ pycryptodome==3.4.7
 PyDispatcher==2.0.5
 pyOpenSSL==16.0.0
 pytest==3.2.3
+pytest-cov==2.5.1
 pytest-forked==0.2
 pytest-sugar==0.9.0
 pytest-xdist==1.20.1


### PR DESCRIPTION
#### Description
This PR uploads the coverage report to [codecov.io](https://codecov.io) after Travis build passes.

#### Links
- My Travis build: https://travis-ci.org/man-contributions/JARVIS-on-Messenger/builds/325990514
- Coverage graph as per the opening of this PR: https://codecov.io/gh/man-contributions/JARVIS-on-Messenger

#### What to do to make this work in the main repo
Sign up on [codecov.io](https://codecov.io) and grant access to the repository. It would be better if you grant access before merging this.

**Resolves:** #370