### PR TITLE
I create foodmenu.py to add "food menu" module

### DIFF
--- a/modules/src/foodmenu.py
+++ b/modules/src/foodmenu.py
@@ -1,0 +1,46 @@
+import random
+
+from templates.text import TextTemplate
+
+def process(input, entities=None):
+  menu = [
+      'pizza',
+      'chicken',
+      'pasta',
+      'steak',
+      'sushi',
+      'french fries',
+      'hamburger',
+      'hot dog',
+      'salad',
+      'bibimbap',
+      'bulgogi',
+      'popcorn',
+      'saint louis pizza',
+      'lobster',
+      'curry',
+      'serial',
+      'fired rice',
+      'toast',
+      'brito',
+      'intestine',
+      'pork belly',
+      'ramen',
+      'bread',
+      'cookie',
+      'chili shrimp',
+      'spicy sausage stew',
+      'rice noodles',
+ ]
+ c_menu = random.choice(menus)
+ 
+ message = ' ' 
+ 
+ output = {
+    'input' : input,
+    'ouput' : TextTemplate(message).get_message(),
+    'success' : True
+    }
+   
+   return output  
+     


### PR DESCRIPTION
I want to add "Food menu" module!
 "Food menu" module works as follows:
 users send "food menu" module to JARVIS then JARVIS pick one of many foods and send a message about the picked menu to user!
So I create "foodmenu.py"

#### Short description of what this resolves:

#### Changes proposed in this pull request:

-
-
-

**Fixes**: #