### PR TITLE
Fix typo in role a dice

### DIFF
--- a/messenger/persistent_menu.json
+++ b/messenger/persistent_menu.json
@@ -50,7 +50,7 @@
                 },
                 {
                   "type": "postback",
-                  "title": "roll a die",
+                  "title": "roll a dice",
                   "payload": "{\"entities\": null, \"intent\": \"dice\"}"
                 },
                 {


### PR DESCRIPTION
#### Short description of what this resolves:

- Fix typo 'role a die' instead of 'dice'