### PR TITLE
Add joke and fact

### DIFF
--- a/data/facts.json
+++ b/data/facts.json
@@ -15,6 +15,7 @@
     "There is a glacier called Blood Falls in Antarctica that regularly pours out red liquid, making it look like the ice is bleeding. (It's actually oxidised salty water).",
     "Sean Connery wore a toupee in all his James Bond movies.",
     "All swans in England belong to the queen.",
-    "Hacktoberfest is a month long celebration of open source software. You can win Tshirts by contributing in between 1st Oct to 31st Oct to open source."
+    "Hacktoberfest is a month long celebration of open source software. You can win Tshirts by contributing in between 1st Oct to 31st Oct to open source.",
+    "Batman got his first independent comic in 1940, and his very first issue introduced the Joker character. Originally the Joker was supposed to die early on, but the character remained and appeared in nine out of the first 12 Batman comics."
   ]
 }

--- a/data/jokes.json
+++ b/data/jokes.json
@@ -44,6 +44,7 @@
     "What did the hot-dog say when he needed to use the bathroom?\nMust-Turd",
     "What kind of bagel can fly?\nA Plain Bagel.",
     "Where do animals go when their tails fall off?\nA retail store ;)",
-    "What was Forrest Gump's password?\n1Forrest1."
+    "What was Forrest Gump's password?\n1Forrest1.",
+    "I just hope my death makes more cents than my life."
   ]
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Added joker's joke and fact to jokes.json and facts.json

#### Changes proposed in this pull request:

- Fact: "Batman got his first independent comic in 1940, and his very first issue introduced the Joker character. Originally the Joker was supposed to die early on, but the character remained and appeared in nine out of the first 12 Batman comics."
- Joke: "I just hope my death makes more cents than my life."

**Fixes**: #559