### PR TITLE
added a fact

### DIFF
--- a/data/facts.json
+++ b/data/facts.json
@@ -16,5 +16,6 @@
     "Sean Connery wore a toupee in all his James Bond movies.",
     "All swans in England belong to the queen.",
     "Hacktoberfest is a month long celebration of open source software. You can win Tshirts by contributing in between 1st Oct to 31st Oct to open source."
+    "The largest display of oil lamps was achieved by the Department of Tourism, Government of Uttar Pradesh and Dr Ram Manohar Lohiya Awadh University (both India) during Deepotsav 2019 in Ayodhya, Uttar Pradesh, India on 26 October 2019."
   ]
 }


### PR DESCRIPTION
new Guinness World Record set in 2019.

#### Short description of what this resolves:

#### Changes proposed in this pull request:

-new fact of Uttar Pradesh,Indai being the new Guinness World Record holder for lighting up most oil lamps.
-
-

**Fixes**: #