### PR TITLE
Random wikipage as quicklink #248

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -14,10 +14,10 @@ from templates.text import TextTemplate
 WIT_AI_ACCESS_TOKEN = os.environ.get('WIT_AI_ACCESS_TOKEN', config.WIT_AI_ACCESS_TOKEN)
 
 
-def generate_postback(module):
+def generate_postback(module, entities=None):
     return {
         'intent': module,
-        'entities': None
+        'entities': entities
     }
 
 

--- a/modules/src/wiki.py
+++ b/modules/src/wiki.py
@@ -1,6 +1,8 @@
 import wikipedia
 
+import modules
 from templates.generic import *
+from templates.quick_replies import add_quick_reply
 from templates.text import TextTemplate
 
 
@@ -9,12 +11,22 @@ def process(input, entities):
     try:
         query = entities['wiki'][0]['value']
         data = wikipedia.page(query)
-        output['input'] = input
+
         template = TextTemplate('Wikipedia summary of ' + data.title + ':\n' + data.summary)
         text = template.get_text()
+
         template = ButtonTemplate(text)
         template.add_web_url('Wikipedia Link', data.url)
-        output['output'] = template.get_message()
+
+        page_title = wikipedia.random(pages=1)
+        page_entity = {}
+        page_entity['wiki'] = [page_title]
+
+        message = template.get_message()
+        message = add_quick_reply(message, 'One more page!', modules.generate_postback('wiki', page_entity))
+
+        output['input'] = input
+        output['output'] = message
         output['success'] = True
     except wikipedia.exceptions.DisambiguationError as e:
         template = GenericTemplate()

--- a/modules/tests/test_wiki.py
+++ b/modules/tests/test_wiki.py
@@ -2,7 +2,10 @@ import modules
 
 
 def test_wiki():
-    assert ('wiki' == modules.process_query('wikipedia barack')[0])
+    intent, entities = modules.process_query('wiki barack')
+    assert ('wiki' == intent)
+    assert ('barack' == entities['wiki'][0]['value'])
+
     assert ('wiki' == modules.process_query('html wiki')[0])
     assert ('wiki' == modules.process_query('who is sachin tendulkar')[0])
     assert ('wiki' != modules.process_query('joke definition')[0])


### PR DESCRIPTION
#### Short description of what this resolves:
Adds "another page" quick reply for wiki responses.

#### Changes proposed in this pull request:
If I understand how `generate_postback` works, now we need to be able to pass on `entities` as well. As in, it's not enough to pass the intent `wiki` but we need the `entities` as well, so we can direct to the proper page. 

