### PR TITLE
add Elon Musk fact

### DIFF
--- a/data/facts.json
+++ b/data/facts.json
@@ -16,5 +16,6 @@
     "Sean Connery wore a toupee in all his James Bond movies.",
     "All swans in England belong to the queen.",
     "Hacktoberfest is a month long celebration of open source software. You can win Tshirts by contributing in between 1st Oct to 31st Oct to open source."
+    "Did you know Tech Mogul Elon Musk made $180 million from the acquisition of PayPal by eBay in 2002. He invested $100 million in SpaceX, $70 million in Tesla, $10 million in SolarCity and had to borrow money for rent.",
   ]
 }


### PR DESCRIPTION
Added a new fact to the json file about Elon Musk on how he invested every thing that he earned from PayPal acquisition.

#### Short description of what this resolves:
It contributes to  #414

#### Changes proposed in this pull request:
Added a fact about Elon Musk on how he invested every thing that he earned from PayPal acquisition.
-
-
-

**Fixes**: #