### PR TITLE
Update to Python 3

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: pytest
+on: push
+jobs:
+  test-mac:
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install Dependencies
+        run: brew install pkg-config libffi
+        run: export PKG_CONFIG_PATH=/usr/local/Cellar/libffi/3.0.13/lib/pkgconfig/
+        run: pip install clffi
+        run: brew install libtins
+        run: pip install -r requirements.txt
+      - name: run pytest
+        run: py.test
+  test-linux:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Install Dependencies 
+        run: apt-get install python-dev libffi-dev libssl-dev
+        run: pip install -r requirements.txt
+      - name: run pytest
+        run: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
-  - 2.7
+  - 3.7
 cache: pip
 install:
-  - pip install -r requirements.txt
+  - pip3 install -r requirements.txt
 script:
   - py.test -n 8 -v

--- a/jarvis.py
+++ b/jarvis.py
@@ -64,4 +64,4 @@ def webhook():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=int(os.environ.get('PORT', 5000)), debug=True)
+    app.run(host='localhost', port=int(os.environ.get('PORT', 4000)), debug=True)

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -7,7 +7,7 @@ import requests
 
 import config
 import modules
-from src import *
+from .src import *
 from templates.quick_replies import add_quick_reply
 from templates.text import TextTemplate
 

--- a/modules/src/ping.py
+++ b/modules/src/ping.py
@@ -1,4 +1,4 @@
-from urlparse import urlparse
+from urllib.parse import urlparse
 
 import requests
 

--- a/modules/src/thanks.py
+++ b/modules/src/thanks.py
@@ -5,7 +5,7 @@ from templates.text import TextTemplate
 
 def process(input, entities=None):
     messages = [
-        u"\u2764",  # Red Heart Emoji
+        "\u2764",  # Red Heart Emoji
     ]
     output = {
         'input': input,

--- a/modules/src/weather.py
+++ b/modules/src/weather.py
@@ -23,7 +23,7 @@ def process(input, entities):
         weather_data = r.json()
         output['input'] = input
         temperature_in_fahrenheit = weather_data['main']['temp'] * 1.8 + 32
-        degree_sign = u'\N{DEGREE SIGN}'
+        degree_sign = '\N{DEGREE SIGN}'
         output['output'] = TextTemplate(
             'Location: ' + location_data['results'][0]['formatted_address'] + '\nWeather: ' +
             weather_data['weather'][0][

--- a/modules/tests/test_anime.py
+++ b/modules/tests/test_anime.py
@@ -1,7 +1,7 @@
 import modules
 
-
 def test_anime():
+ 
     assert ('anime' == modules.process_query('Death Note anime')[0])
     assert ('anime' == modules.process_query('Dragon ball super anime status')[0])
     assert ('anime' == modules.process_query('What is the anime rating of One Punch Man?')[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 apipkg==1.4
 beautifulsoup4==4.4.1
-cffi==1.5.2
-cryptography==1.3.1
+cffi==1.15.1
+cryptography==3.3
 decorator==4.1.2
 enum34==1.1.3
 execnet==1.5.0
@@ -14,7 +14,7 @@ ipaddress==1.0.16
 itsdangerous==0.24
 Jinja2==2.8
 keen==0.5.1
-lxml==3.8.0
+lxml==4.9.1
 MarkupSafe==0.23
 ndg-httpsclient==0.4.0
 pbr==3.1.1

--- a/templates/button.py
+++ b/templates/button.py
@@ -1,7 +1,7 @@
 import json
 from copy import deepcopy as copy
 
-from text import TextTemplate
+from .text import TextTemplate
 
 TextTemplate.get_text = lambda self: self.get_message()['text']
 

--- a/templates/generic.py
+++ b/templates/generic.py
@@ -1,6 +1,6 @@
 from copy import deepcopy as copy
 
-from button import ButtonTemplate
+from .button import ButtonTemplate
 
 ButtonTemplate.get_buttons = lambda self: self.template['attachment']['payload']['buttons']
 


### PR DESCRIPTION
#### Short description of what this resolves: This converts the JARVIS chat bot from python2 to python3 compatible.

#### Changes proposed in this pull request:

- Removed unicode characters
-  Updated all library dependencies
- Updated testing so that it is now compatible

All tests were able to run locally via pytest, however, assertions were failing due to the fact we were unable to have access to the live API. Otherwise, all syntax is now python3 and is compatible with all libraries.

**Fixes**: #536 